### PR TITLE
Linking everything as static library.

### DIFF
--- a/src/mqueue/CMakeLists.txt
+++ b/src/mqueue/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SOURCES
   src/mq_unlink.c
 )
 
-add_library(mqueue ${SOURCES})
+add_library(mqueue STATIC ${SOURCES})
 target_include_directories(mqueue PUBLIC include/mqueue)
 target_link_libraries(mqueue rt)
 

--- a/src/pthread/CMakeLists.txt
+++ b/src/pthread/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(posix-macos-pthread posix-macos-pthread.c)
+add_library(posix-macos-pthread STATIC posix-macos-pthread.c)
 target_include_directories(posix-macos-pthread PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 install(TARGETS posix-macos-pthread)

--- a/src/semaphore/CMakeLists.txt
+++ b/src/semaphore/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(posix-macos-semaphore
   posix-macos-semaphore2.c
 )
 
-target_include_directories(posix-macos-semaphore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(posix-macos-semaphore STATIC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS posix-macos-semaphore)
 install(FILES posix-macos-semaphore.h TYPE INCLUDE)

--- a/src/time/CMakeLists.txt
+++ b/src/time/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(posix-macos-time posix-macos-time.c)
-target_include_directories(posix-macos-time PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(posix-macos-time STATIC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS posix-macos-time)
 install(FILES posix-macos-time.h TYPE INCLUDE)

--- a/src/timer/CMakeLists.txt
+++ b/src/timer/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(posix-macos-timer posix-macos-timer.c)
-target_include_directories(posix-macos-timer PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(posix-macos-timer STATIC PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 install(TARGETS posix-macos-timer)
 install(FILES posix-macos-timer.h TYPE INCLUDE)


### PR DESCRIPTION
I feel that here is missed `STATIC` keyword. Without it a build which is tried ot use this library will fails on linking with some undefined symbols which is related to asan.